### PR TITLE
Feat: Add Carousel for follower`s cards

### DIFF
--- a/src/components/CardListFetcher.tsx
+++ b/src/components/CardListFetcher.tsx
@@ -53,12 +53,12 @@ const CardListFetcher = ({
 
   const deps = [...gameDeps, currentPage, refresh];
 
-  const cardList: any = fetchCardList(`/api/${game}/boards`, config, deps);
+  const response: any = fetchCardList(`/api/${game}/boards`, config, deps);
 
   useEffect(() => {
-    dispatch(cardActions.SET_TOTAL_PAGE(cardList?.totalPage));
-    dispatch(cardActions.SET_CARDS({ game, cardList: cardList?.content }));
-  }, [cardList, dispatch]);
+    dispatch(cardActions.SET_TOTAL_PAGE(response?.totalPage));
+    dispatch(cardActions.SET_CARDS({ game, cardList: response?.content }));
+  }, [response, dispatch]);
 
   return <div>{children}</div>;
 };

--- a/src/components/followersCard/FollowCardListContainer.tsx
+++ b/src/components/followersCard/FollowCardListContainer.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
 // mui
 import { styled } from '@mui/system';
 import MuiBox from '@mui/material/Box';
+import MuiButton from '@mui/material/Button';
 import MuiTypography from '@mui/material/Typography';
+import MuiContainer from '@mui/material/Container';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
 
 import { RootState } from 'store';
 import { getCurrentGame, isInParty } from 'functions/commons';
@@ -38,64 +42,148 @@ const Card = ({
 const FollowCardListContainer = () => {
   const currentGame: GAME_ID = getCurrentGame();
 
+  const { followCards } = useSelector((state: RootState) => state.card);
   const { oauth2Id } = useSelector((state: RootState) => state.user);
 
-  const { followCards } = useSelector((state: RootState) => state.card);
+  const listRef: React.MutableRefObject<any> = useRef();
+  const rightBtnRef: React.MutableRefObject<any> = useRef();
+  const leftBtnRef: React.MutableRefObject<any> = useRef();
+
+  const [position, setPosition] = useState<number>(0);
+  const [isBtnDisabled, setIsBtnDisabled] = useState<boolean>(true);
+
+  const handleClick = (direction: string) => {
+    const leftBtnleft = leftBtnRef.current.getBoundingClientRect().left;
+    const rightBtnRight = rightBtnRef.current.getBoundingClientRect().right;
+    const listWidth = listRef.current.getBoundingClientRect().width;
+    const slideDistance = rightBtnRight - leftBtnleft;
+
+    if (direction === 'left') {
+      setPosition((prev) => {
+        if (prev - slideDistance <= 0) {
+          return 0;
+        }
+        return prev - slideDistance;
+      });
+    } else if (direction === 'right') {
+      setPosition((prev) => {
+        if (prev + slideDistance >= listWidth - slideDistance) {
+          return listWidth - slideDistance;
+        }
+        return prev + slideDistance;
+      });
+    }
+  };
+
+  useEffect(() => {
+    const listWidth = listRef.current.getBoundingClientRect().width;
+    const slideDistance =
+      rightBtnRef.current.getBoundingClientRect().right -
+      leftBtnRef.current.getBoundingClientRect().left;
+
+    if (listWidth <= slideDistance) {
+      setIsBtnDisabled(true);
+    } else {
+      setIsBtnDisabled(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    listRef.current.style.transform = `translateX(-${position}px)`;
+  }, [position]);
+
+  const cardList = followCards[currentGame];
 
   let NumOfCards = 0;
 
-  if (followCards[currentGame]) {
-    NumOfCards = followCards[currentGame].length;
+  if (cardList) {
+    NumOfCards = cardList?.length;
   }
 
-  const arrayForDummies = new Array(3 - NumOfCards)
-    .fill(0)
-    .map((value, i) => `dummies_${i}`);
-
   return (
-    <>
-      {followCards[currentGame] && (
-        <Header>
-          <Title>팔로우한 사용자들의 새 게시글</Title>
-        </Header>
-      )}
-      <CardsWrapper>
-        {followCards[currentGame] &&
-          followCards[currentGame].map((aCard: any) => {
-            return (
-              <Link
-                key={aCard.id}
-                to={
-                  aCard.finished === 'true' &&
-                  isInParty(aCard.memberList, oauth2Id)
-                    ? `${aCard.id}/review`
-                    : `${aCard.id}`
-                }
-                state={{ background: `/${currentGame}` }}
-                style={{
-                  textDecoration: 'none',
-                  background: 'fixed',
-                  margin: '0 8px 8px 0',
-                }}
-              >
-                <Card
-                  game={currentGame}
-                  item={aCard}
+    <Container maxWidth="lg">
+      <CardCarousel className="movie-row">
+        {cardList && (
+          <Header>
+            <Title>팔로우한 사용자들의 새 게시글</Title>
+          </Header>
+        )}
+        <MuiBox sx={{ position: 'relative' }}>
+          <CarouselBtn
+            sx={{ left: 0, p: 0, m: 0 }}
+            onClick={() => handleClick('left')}
+            ref={leftBtnRef}
+            disabled={isBtnDisabled}
+          >
+            <NavigateBeforeIcon sx={{ fontSize: 30 }} />
+          </CarouselBtn>
+          <CarouselBtn
+            sx={{ right: 0 }}
+            onClick={() => handleClick('right')}
+            disabled={isBtnDisabled}
+            ref={rightBtnRef}
+          >
+            <NavigateNextIcon sx={{ fontSize: 30 }} />
+          </CarouselBtn>
+
+          <CardsWrapper ref={listRef}>
+            {NumOfCards > 0 &&
+              cardList.map((aCard: any, index) => (
+                <Link
                   key={aCard.id}
-                  expired={aCard.expired === 'true'}
-                />
-              </Link>
-            );
-          })}
-        {arrayForDummies.map((item) => (
-          <DummyCard key={item} />
-        ))}
-      </CardsWrapper>
-    </>
+                  to={
+                    aCard.finished === 'true' &&
+                    isInParty(aCard.memberList, oauth2Id)
+                      ? `${aCard.id}/review`
+                      : `${aCard.id}`
+                  }
+                  state={{ background: `/${currentGame}` }}
+                  style={{
+                    textDecoration: 'none',
+                    background: 'fixed',
+                    margin: '0 8px 0 0',
+                  }}
+                >
+                  <Card
+                    game={currentGame}
+                    item={aCard}
+                    key={aCard.id}
+                    expired={aCard.expired === 'true'}
+                  />
+                </Link>
+              ))}
+          </CardsWrapper>
+        </MuiBox>
+      </CardCarousel>
+    </Container>
   );
 };
 
 export default FollowCardListContainer;
+
+const Container = styled(MuiContainer)(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '0 0 10px 0',
+  justifyContent: 'center',
+})) as typeof MuiContainer;
+
+const CardCarousel = styled(MuiBox)(({ theme }) => ({
+  [theme.breakpoints.up('xs')]: {
+    width: '368px',
+  },
+  [theme.breakpoints.up('md')]: {
+    width: '736px',
+  },
+  [theme.breakpoints.up('lg')]: {
+    width: '1104px',
+  },
+  [theme.breakpoints.up('xl')]: {
+    width: '1104px',
+  },
+  overflow: 'hidden',
+})) as typeof MuiBox;
 
 const Header = styled(MuiBox)(() => ({
   width: '100%',
@@ -111,14 +199,30 @@ const Title = styled(MuiTypography)(() => ({
 })) as typeof MuiTypography;
 
 const CardsWrapper = styled(MuiBox)(() => ({
-  width: '100%',
   display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'flex-start',
-  flexWrap: 'wrap',
-  padding: '0 0 10px 0',
+  width: 'max-content',
+  transform: 'translateX()',
+  transition: 'all ease 1s',
 })) as typeof MuiBox;
 
 const DummyCard = styled(MuiBox)(() => ({
   width: '368px',
 })) as typeof MuiBox;
+
+const CarouselBtn = styled(MuiButton)(() => ({
+  '&:disabled': {
+    opacity: '0',
+  },
+  height: '100%',
+  color: '#000000',
+  '&:hover': {
+    backgroundColor: '#3d393915',
+  },
+  position: 'absolute',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: 1100,
+  cursor: 'pointer',
+  overflow: 'hidden',
+})) as typeof MuiButton;

--- a/src/components/followersCard/FollowCardListContainer.tsx
+++ b/src/components/followersCard/FollowCardListContainer.tsx
@@ -42,26 +42,26 @@ const FollowCardListContainer = () => {
 
   const { followCards } = useSelector((state: RootState) => state.card);
 
-  let cardLength = 0;
+  let NumOfCards = 0;
 
-  if (followCards) {
-    cardLength = followCards.length;
+  if (followCards[currentGame]) {
+    NumOfCards = followCards[currentGame].length;
   }
 
-  const arrayForDummies = new Array(3 - cardLength)
+  const arrayForDummies = new Array(3 - NumOfCards)
     .fill(0)
     .map((value, i) => `dummies_${i}`);
 
   return (
     <>
-      {followCards && (
+      {followCards[currentGame] && (
         <Header>
           <Title>팔로우한 사용자들의 새 게시글</Title>
         </Header>
       )}
       <CardsWrapper>
-        {followCards &&
-          followCards.map((aCard: any) => {
+        {followCards[currentGame] &&
+          followCards[currentGame].map((aCard: any) => {
             return (
               <Link
                 key={aCard.id}

--- a/src/components/followersCard/FollowCardListContainer.tsx
+++ b/src/components/followersCard/FollowCardListContainer.tsx
@@ -82,9 +82,9 @@ const FollowCardListContainer = () => {
       leftBtnRef.current.getBoundingClientRect().left;
 
     if (listWidth <= slideDistance) {
-      setIsBtnDisabled(true);
-    } else {
       setIsBtnDisabled(false);
+    } else {
+      setIsBtnDisabled(true);
     }
   }, []);
 

--- a/src/components/followersCard/FollowCardListContainer.tsx
+++ b/src/components/followersCard/FollowCardListContainer.tsx
@@ -155,7 +155,7 @@ const FollowCardListContainer = () => {
               ))}
           </CardsWrapper>
         </MuiBox>
-        {cardList && <MuiDivider sx={{ mt: '20px' }} />}
+        {cardList && <MuiDivider sx={{ mt: '10px' }} />}
       </CardCarousel>
     </Container>
   );

--- a/src/components/followersCard/FollowCardListContainer.tsx
+++ b/src/components/followersCard/FollowCardListContainer.tsx
@@ -10,6 +10,7 @@ import MuiTypography from '@mui/material/Typography';
 import MuiContainer from '@mui/material/Container';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import MuiDivider from '@mui/material/Divider';
 
 import { RootState } from 'store';
 import { getCurrentGame, isInParty } from 'functions/commons';
@@ -154,6 +155,7 @@ const FollowCardListContainer = () => {
               ))}
           </CardsWrapper>
         </MuiBox>
+        {cardList && <MuiDivider sx={{ mt: '20px' }} />}
       </CardCarousel>
     </Container>
   );

--- a/src/components/followersCard/FollowCardListFetcher.tsx
+++ b/src/components/followersCard/FollowCardListFetcher.tsx
@@ -37,7 +37,12 @@ const CardListFetcher = ({ children, game, refresh }: CardListFetcherProps) => {
 
     useEffect(() => {
       dispatch(cardActions.SET_F_TOTAL_PAGE(followCardList?.totalPage));
-      dispatch(cardActions.SET_FOLLOW_CARDS(followCardList?.content));
+      dispatch(
+        cardActions.SET_FOLLOW_CARDS({
+          game,
+          cardList: followCardList?.content,
+        }),
+      );
     }, [followCardList, dispatch]);
   }
 

--- a/src/components/followersCard/FollowCardListFetcher.tsx
+++ b/src/components/followersCard/FollowCardListFetcher.tsx
@@ -20,7 +20,7 @@ const CardListFetcher = ({ children, game, refresh }: CardListFetcherProps) => {
 
   const followConfing = {
     params: {
-      size: 3,
+      size: 12,
       page: followCurrentPage || 0,
       game,
     },

--- a/src/components/followersCard/FollowersCard.tsx
+++ b/src/components/followersCard/FollowersCard.tsx
@@ -12,11 +12,9 @@ import { RootState } from 'store';
 import FollowCardListContainer from 'components/followersCard/FollowCardListContainer';
 import FollowCardListFetcher from 'components/followersCard/FollowCardListFetcher';
 import Circular from 'components/loading/Circular';
-import { getCurrentGame } from 'functions/commons';
+import { GAME_ID } from 'types/games';
 
-const FollowersCard = () => {
-  const currentGame = getCurrentGame();
-
+const FollowersCard = ({ game }: { game: GAME_ID }) => {
   const { remainingTime } = useSelector((state: RootState) => state.refresh);
 
   const [refresh, setRefresh] = React.useState<number>(0);
@@ -34,7 +32,7 @@ const FollowersCard = () => {
       FallbackComponent={FollowCardListErrorFallback}
     >
       <Suspense fallback={<CardListFetcherFallback />}>
-        <FollowCardListFetcher game={currentGame} refresh={refresh}>
+        <FollowCardListFetcher game={game} refresh={refresh}>
           <FollowCardListContainer />
         </FollowCardListFetcher>
       </Suspense>

--- a/src/components/followersCard/FollowersCard.tsx
+++ b/src/components/followersCard/FollowersCard.tsx
@@ -22,7 +22,6 @@ const FollowersCard = ({ game }: { game: GAME_ID }) => {
   useEffect(() => {
     if (remainingTime < 1) {
       setRefresh((prev) => prev + 1);
-      console.log('refreshed');
     }
   }, [remainingTime]);
 

--- a/src/pages/battlegrounds/CardListContainer.tsx
+++ b/src/pages/battlegrounds/CardListContainer.tsx
@@ -71,7 +71,7 @@ const CardsWrapper = styled(MuiBox)(() => ({
   justifyContent: 'center',
   alignItems: 'flex-start',
   flexWrap: 'wrap',
-  padding: '10px 0 20px 0',
+  padding: 'o 0 20px 0',
   overflowY: 'auto',
 })) as typeof MuiBox;
 

--- a/src/pages/battlegrounds/EmptySlot.tsx
+++ b/src/pages/battlegrounds/EmptySlot.tsx
@@ -14,6 +14,7 @@ import { snackbarActions } from 'store/snackbar-slice';
 import { refreshActions } from 'store/refresh-slice';
 import { loadHistory, getPlatform } from 'apis/api/pubg';
 import { addPartyMemberWithName } from 'apis/api/common';
+import { getIsBanned, isInParty } from 'functions/commons';
 
 // 방장이 아닌 유저
 const DefaultEmptySlot = () => {
@@ -99,7 +100,7 @@ const EmptySlotForAuthor = ({ platform }: any) => {
       }
       // 전적이 없어서 플랫폼 조회가 불가능한 경우
 
-      if (currentCard.banList.includes(name)) {
+      if (getIsBanned(currentCard.banList, `guest${name}`)) {
         dispatch(
           snackbarActions.OPEN_SNACKBAR({
             message: '파티에서 강제퇴장 당한 사용자입니다.',
@@ -108,7 +109,7 @@ const EmptySlotForAuthor = ({ platform }: any) => {
         );
         return;
       }
-      if (currentCard.memberList.includes(name)) {
+      if (isInParty(currentCard.memberList, `guest${name}`)) {
         dispatch(
           snackbarActions.OPEN_SNACKBAR({
             message: '이미 파티에 참여한 사용자입니다.',

--- a/src/pages/battlegrounds/MemberSlot.tsx
+++ b/src/pages/battlegrounds/MemberSlot.tsx
@@ -9,15 +9,11 @@ import { styled } from '@mui/system';
 import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import MuiIconButton from '@mui/material/IconButton';
-import MuiImageList from '@mui/material/ImageList';
 import MuiToolTip from '@mui/material/Tooltip';
 import PersonAdd from '@mui/icons-material/PersonAdd';
 import NotInterestedIcon from '@mui/icons-material/NotInterested';
 
-import Close from '@mui/icons-material/Close';
-
 import { RootState } from 'store';
-
 import Circular from 'components/loading/Circular';
 import { snackbarActions } from 'store/snackbar-slice';
 import { refreshActions } from 'store/refresh-slice';

--- a/src/pages/battlegrounds/MemberSlot.tsx
+++ b/src/pages/battlegrounds/MemberSlot.tsx
@@ -288,7 +288,8 @@ const MemberSlot = ({ name, oauth2Id: MemberOauth2Id }: MemberSlotProps) => {
               </MuiToolTip>
             )}
             {isInParty(currentCard.memberList, oauth2Id) &&
-              oauth2Id !== MemberOauth2Id && (
+              oauth2Id !== MemberOauth2Id &&
+              !MemberOauth2Id.startsWith('guest') && (
                 <MuiToolTip title="팔로우" placement="right">
                   <IconButton onClick={handleFollow}>
                     <PersonAdd />

--- a/src/pages/battlegrounds/main.tsx
+++ b/src/pages/battlegrounds/main.tsx
@@ -75,7 +75,7 @@ const Main = () => {
   return (
     <>
       <CardFilter filterProps={filterProps} />
-      {isLogin && <FollowersCard />}
+      {isLogin && <FollowersCard game="pubg" />}
       <ErrorBoundary
         resetKeys={gameDeps}
         FallbackComponent={CardListErrorFallback}

--- a/src/pages/leagueoflegends/Card.tsx
+++ b/src/pages/leagueoflegends/Card.tsx
@@ -254,7 +254,7 @@ const Card = ({ item, expired }: CardProps) => {
                 {item.author.mostChampion.map((aChampion, index) => {
                   return (
                     <ImageListItem
-                      key={aChampion}
+                      key={`most_${index + 1}_${aChampion}`}
                       sx={{
                         width: '44px',
                         height: '44px',

--- a/src/pages/leagueoflegends/CardListContainer.tsx
+++ b/src/pages/leagueoflegends/CardListContainer.tsx
@@ -71,7 +71,7 @@ const CardsWrapper = styled(MuiBox)(() => ({
   justifyContent: 'center',
   alignItems: 'flex-start',
   flexWrap: 'wrap',
-  padding: '10px 0 20px 0',
+  padding: '0 0 20px 0',
   overflowY: 'auto',
 })) as typeof MuiBox;
 

--- a/src/pages/leagueoflegends/EmptySlot.tsx
+++ b/src/pages/leagueoflegends/EmptySlot.tsx
@@ -14,6 +14,7 @@ import { refreshActions } from 'store/refresh-slice';
 import { snackbarActions } from 'store/snackbar-slice';
 import { loadHistory, verifyNickname } from 'apis/api/leagueoflegends';
 import { addPartyMemberWithName } from 'apis/api/common';
+import { getIsBanned, isInParty } from 'functions/commons';
 
 // 방장이 아닌 사용자의 경우
 const DefaultEmptySlot = () => {
@@ -55,7 +56,7 @@ const EmptySlotForAuthor = () => {
 
       // 닉네임 인증
       const exactNickname = await verifyNickname(name.trim());
-      if (currentCard.banList.includes(exactNickname)) {
+      if (getIsBanned(currentCard.banList, `guest${exactNickname}`)) {
         dispatch(
           snackbarActions.OPEN_SNACKBAR({
             message: '파티에서 강제퇴장 당한 사용자입니다.',
@@ -64,7 +65,7 @@ const EmptySlotForAuthor = () => {
         );
         return;
       }
-      if (currentCard.memberList.includes(exactNickname)) {
+      if (isInParty(currentCard.memberList, `guest${exactNickname}`)) {
         dispatch(
           snackbarActions.OPEN_SNACKBAR({
             message: '이미 파티에 참여한 사용자입니다.',

--- a/src/pages/leagueoflegends/MemberSlot.tsx
+++ b/src/pages/leagueoflegends/MemberSlot.tsx
@@ -271,7 +271,8 @@ const MemberSlot = ({
               </MuiToolTip>
             )}
             {isInParty(currentCard.memberList, oauth2Id) &&
-              oauth2Id !== MemberOauth2Id && (
+              oauth2Id !== MemberOauth2Id &&
+              !MemberOauth2Id.startsWith('guest') && (
                 <MuiToolTip title="팔로우" placement="right">
                   <IconButton onClick={handleFollow}>
                     <PersonAdd />

--- a/src/pages/leagueoflegends/MemberSlot.tsx
+++ b/src/pages/leagueoflegends/MemberSlot.tsx
@@ -239,7 +239,7 @@ const MemberSlot = ({
               {memberInfo &&
                 memberInfo.mostChampion?.map(
                   (aChampion: string, index: number) => (
-                    <ChampImgWrapper key={aChampion + Math.random()}>
+                    <ChampImgWrapper key={`most_${index + 1}_aChampion`}>
                       <img
                         src={
                           aChampion === 'poro'

--- a/src/pages/leagueoflegends/main.tsx
+++ b/src/pages/leagueoflegends/main.tsx
@@ -86,7 +86,7 @@ const Main = () => {
   return (
     <>
       <CardFilter filterProps={filterProps} />
-      {isLogin && <FollowersCard />}
+      {isLogin && <FollowersCard game="lol" />}
       <ErrorBoundary
         resetKeys={gameDeps}
         FallbackComponent={CardListErrorFallback}

--- a/src/pages/overwatch/Card.tsx
+++ b/src/pages/overwatch/Card.tsx
@@ -351,7 +351,7 @@ const Card = ({ item, expired }: CardProps) => {
                 {item.author.mostHero.map((aHero, index) => {
                   return (
                     <ImageListItem
-                      key={aHero}
+                      key={`most_${index + 1}_${aHero}`}
                       sx={{
                         width: '44px',
                         height: '44px',

--- a/src/pages/overwatch/CardListContainer.tsx
+++ b/src/pages/overwatch/CardListContainer.tsx
@@ -71,7 +71,7 @@ const CardsWrapper = styled(MuiBox)(() => ({
   justifyContent: 'center',
   alignItems: 'flex-start',
   flexWrap: 'wrap',
-  padding: '10px 0 20px 0',
+  padding: '0 0 20px 0',
   overflowY: 'auto',
 })) as typeof MuiBox;
 

--- a/src/pages/overwatch/EmptySlot.tsx
+++ b/src/pages/overwatch/EmptySlot.tsx
@@ -14,6 +14,7 @@ import { refreshActions } from 'store/refresh-slice';
 import { snackbarActions } from 'store/snackbar-slice';
 import { addPartyMemberWithName } from 'apis/api/common';
 import { loadHistory, verifyNickname } from 'apis/api/overwatch';
+import { getIsBanned, isInParty } from 'functions/commons';
 
 // 방장이 아닌 사용자의 경우
 const DefaultEmptySlot = () => {
@@ -62,7 +63,7 @@ const EmptySlotForAuthor = () => {
 
       // 닉네임 인증
       const isExist = await verifyNickname(name.trim());
-      if (isExist && currentCard.banList.includes(name.trim())) {
+      if (getIsBanned(currentCard.banList, `guest${name.trim()}`)) {
         dispatch(
           snackbarActions.OPEN_SNACKBAR({
             message: '파티에서 강제퇴장 당한 사용자입니다.',
@@ -71,7 +72,7 @@ const EmptySlotForAuthor = () => {
         );
         return;
       }
-      if (currentCard.memberList.includes(name.trim())) {
+      if (isInParty(currentCard.memberList, `guest${name.trim()}`)) {
         dispatch(
           snackbarActions.OPEN_SNACKBAR({
             message: '이미 파티에 참여한 사용자입니다.',

--- a/src/pages/overwatch/MemberSlot.tsx
+++ b/src/pages/overwatch/MemberSlot.tsx
@@ -354,10 +354,10 @@ const MemberSlot = ({ name, oauth2Id: MemberOauth2Id }: MemberSlotProps) => {
               cols={3}
               gap={4}
             >
-              {memberInfo?.mostHero.map((aHero: string, _index: number) => {
+              {memberInfo?.mostHero.map((aHero: string, index: number) => {
                 return (
                   <ImageListItem
-                    key={aHero}
+                    key={`most_${index + 1}_${aHero}`}
                     sx={{
                       width: '44px',
                       height: '44px',

--- a/src/pages/overwatch/MemberSlot.tsx
+++ b/src/pages/overwatch/MemberSlot.tsx
@@ -390,7 +390,8 @@ const MemberSlot = ({ name, oauth2Id: MemberOauth2Id }: MemberSlotProps) => {
               </MuiToolTip>
             )}
             {isInParty(currentCard.memberList, oauth2Id) &&
-              oauth2Id !== MemberOauth2Id && (
+              oauth2Id !== MemberOauth2Id &&
+              !MemberOauth2Id.startsWith('guest') && (
                 <MuiToolTip title="팔로우" placement="right">
                   <IconButton onClick={handleFollow}>
                     <PersonAdd />

--- a/src/pages/overwatch/main.tsx
+++ b/src/pages/overwatch/main.tsx
@@ -86,7 +86,7 @@ const Main = () => {
   return (
     <>
       <CardFilter filterProps={filterProps} />
-      {isLogin && <FollowersCard />}
+      {isLogin && <FollowersCard game="overwatch" />}
       <ErrorBoundary
         resetKeys={gameDeps}
         FallbackComponent={CardListErrorFallback}

--- a/src/pages/register/Games.tsx
+++ b/src/pages/register/Games.tsx
@@ -26,8 +26,6 @@ const Games = () => {
       const response = await defaultAxios.post('/api/valorant/user/exist', {
         code: rsoAccessCode as string,
       });
-
-      console.log(response);
     };
 
     if (rsoAccessCode) {

--- a/src/store/card-slice.ts
+++ b/src/store/card-slice.ts
@@ -1,11 +1,17 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { GAME_ID } from 'types/games';
 
 interface IState {
   lolCards: [];
   pubgCards: [];
   overwatchCards: [];
   valorantCards: [];
-  followCards: [];
+  followCards: {
+    lol: [];
+    pubg: [];
+    overwatch: [];
+    valorant: [];
+  };
   currentPage: number;
   totalPage: number;
   followCurrentPage: number;
@@ -19,7 +25,12 @@ const initialState: IState = {
   pubgCards: [],
   overwatchCards: [],
   valorantCards: [],
-  followCards: [],
+  followCards: {
+    lol: [],
+    pubg: [],
+    overwatch: [],
+    valorant: [],
+  },
   currentPage: 0,
   totalPage: 0,
   followCurrentPage: 0,
@@ -51,8 +62,17 @@ const cardSlice = createSlice({
           break;
       }
     },
-    SET_FOLLOW_CARDS: (state, action) => {
-      state.followCards = action.payload;
+    SET_FOLLOW_CARDS: (
+      state,
+      action: {
+        payload: {
+          game: GAME_ID;
+          cardList: any;
+        };
+      },
+    ) => {
+      const { game, cardList } = action.payload;
+      state.followCards[game] = cardList;
     },
     SET_CURRENT_PAGE: (state, action) => {
       state.currentPage = action.payload;


### PR DESCRIPTION
## Description
사용자가 팔로우 중인 사용자들의 게시글을 위한 carousel

## Changes
- 1 기존  게시글 영역을 대체하도록 수정
- 2 영역보다 게시글이 적으면 버튼 안보이도록 수정

## Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
